### PR TITLE
Remove code bloat of unnecessary conditionals in a large class

### DIFF
--- a/trails-app/src/classes/Gear.js
+++ b/trails-app/src/classes/Gear.js
@@ -3,34 +3,14 @@ class Gear{
         this.hike = hike;
         this.weather = hike.weather[0].description;
         this.temp = hike.temp;
-        this.rain = this.isRaining();
-        this.sun = this.isSunny();
+        this.rain = this.weather.includes("rain");
+        this.sun = this.weather.includes("clear");
         this.head = this.headClothing();
         this.top = this.mainClothing("top");
         this.bottom = this.mainClothing("bottom");
         this.other = this.otherClothing();
         this.calories = this.calcCalories();
         this.water = this.calcWater();
-    }
-
-    //Instantiation Method - determines if weather is rainy
-    isRaining(){
-        if(this.weather.includes("rain")){
-            return true;
-        }
-        else {
-            return false;
-        }
-    }
-
-    //Instantiation Method - determines if weather is sunny
-    isSunny(){
-        if(this.weather.includes("clear")){
-            return true;
-        }
-        else {
-            return false;
-        }
     }
 
     //Instantiation Method - determines recommended head clothing


### PR DESCRIPTION
Code Smell #2: Large Class/Duplicate Code

Removed two methods that simply returned true or false based on other primitives' values. Extracted the boolean expression to be directly called in the constructor to shorten a somewhat large class. Also, eliminated unnecessary conditionals in the process in line with the object-orientation abuser smell.