### PR TITLE
Fixes to Jay's github issues

### DIFF
--- a/trails-app/package-lock.json
+++ b/trails-app/package-lock.json
@@ -12552,6 +12552,11 @@
         "workbox-webpack-plugin": "5.1.4"
       }
     },
+    "react-tiny-link": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/react-tiny-link/-/react-tiny-link-3.6.0.tgz",
+      "integrity": "sha512-uixE/1+IDKVcobnjZQpMafkBT/JQjdgt6kvBZ8AG4uSZ46ECi2HFT5R/TLokQoBJipU4dDs4Mph2AN4BGQMvkQ=="
+    },
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",

--- a/trails-app/package.json
+++ b/trails-app/package.json
@@ -17,6 +17,7 @@
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.0",
+    "react-tiny-link": "^3.6.0",
     "web-vitals": "^0.2.4"
   },
   "scripts": {

--- a/trails-app/src/App.css
+++ b/trails-app/src/App.css
@@ -146,6 +146,10 @@ body{
 
 }
 
+.result-temp-small {
+  display: none;
+}
+
 .result-act-dist{
   border-right-style:solid;
   border-width: .1em;
@@ -156,8 +160,16 @@ body{
       display: none;
   }
 
+  .result-temp{
+    display: none;
+  }
+
+  .result-temp-small {
+    display: block;
+  }
+
   .result-detail-text .result-act-dist {
     border-style: none;
   }
-
 }
+

--- a/trails-app/src/App.css
+++ b/trails-app/src/App.css
@@ -37,41 +37,6 @@ body{
   margin: 20px;
 }
 
-/*CODE SMELL: DEAD CODE
-
-.content li {
-  margin-bottom: 10px;
-}
-
-.header{
-  display: inline-block;
-  position: relative;
-  background-color: orange;
-  height: 5vh;
-  width: 100%;
-  align-items: center;
-  flex-direction: column;
-  overflow: hidden;
-}
-
-.ProfBtn{
-  margin-right: 2.5vh;
-  float: right;
-  margin-top: 1.5vh;
-  cursor:pointer;
-  border:none;
-}
-
-.HomeBtn{
-  cursor:pointer;
-  margin-left: 4vh;
-  margin-top: 1.5vh;
-  float: left;
-  border:none;
-}
-
-*/
-
 .search-container{
   height: 50vh;
   width: 100%;

--- a/trails-app/src/App.css
+++ b/trails-app/src/App.css
@@ -155,21 +155,36 @@ body{
   border-width: .1em;
 }
 
+/* ListItem configuration for window size less than 1026px */
 @media only screen and (max-width: 1026px) {
   .result-summary {
       display: none;
   }
-
   .result-temp{
     display: none;
   }
-
   .result-temp-small {
     display: block;
   }
-
   .result-detail-text .result-act-dist {
     border-style: none;
+  }
+}
+/* ListItem configuration for window size less than 700px */
+@media only screen and (max-width: 700px) {
+  .result-img {
+    height: 5em;
+    object-fit: cover;
+    width: 5em;
+    border-top-left-radius: 1em;
+    border-bottom-left-radius: 1em;
+  }
+  .result-title-text{
+    font-size: 10px;
+  
+  }
+  .result-detail-text {
+    font-size: 7px;
   }
 }
 

--- a/trails-app/src/App.css
+++ b/trails-app/src/App.css
@@ -170,21 +170,15 @@ body{
     border-style: none;
   }
 }
-/* ListItem configuration for window size less than 700px */
-@media only screen and (max-width: 700px) {
-  .result-img {
-    height: 5em;
-    object-fit: cover;
-    width: 5em;
-    border-top-left-radius: 1em;
-    border-bottom-left-radius: 1em;
-  }
+/* ListItem configuration for window size less than 800px */
+@media only screen and (max-width: 800px) {
+
   .result-title-text{
-    font-size: 10px;
+    font-size: 25px;
   
   }
   .result-detail-text {
-    font-size: 7px;
+    font-size: 22px;
   }
 }
 

--- a/trails-app/src/components/ListItem.js
+++ b/trails-app/src/components/ListItem.js
@@ -12,15 +12,14 @@ export default function ListItem(props){
                     <span className= "result-act-dist">
                     <p className = 'result-activity'>Activity Level: {props.activityLevel}</p>
                     <p className = 'result-distance'>Distance: {props.distance}</p>
+                    <p className = 'result-temp-small'>Current Temp: {props.temp}</p>
                     </span>
                     <span className = 'result-summary'>Summary: {props.summary}</span>  
                 </div>
             </div>
             <p className = 'result-temp'>Current Temp: {props.temp}</p>
             
-            <div className = 'result-temp-small'>
-                <p>Current Temp: {props.temp}</p>
-            </div>
+
         </div>
     )
 }

--- a/trails-app/src/components/ListItem.js
+++ b/trails-app/src/components/ListItem.js
@@ -17,6 +17,10 @@ export default function ListItem(props){
                 </div>
             </div>
             <p className = 'result-temp'>Current Temp: {props.temp}</p>
+            
+            <div className = 'result-temp-small'>
+                <p>Current Temp: {props.temp}</p>
+            </div>
         </div>
     )
 }

--- a/trails-app/src/components/Map.js
+++ b/trails-app/src/components/Map.js
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import { ReactTinyLink } from 'react-tiny-link'
 
 export default function Map(props) {
     var lat = props.searchObj.results[props.hikeIndex].lat
@@ -11,6 +11,14 @@ export default function Map(props) {
             <img className="google-image" src="https://www.xda-developers.com/files/2019/06/google-maps-india.jpg"/>
             <br></br>
             <a href={mapURL} target = "_blank" >Click here for directions</a>
+            <ReactTinyLink
+            cardSize="large"
+            showGraphic={true}
+            description ="Click here for directions to your hike."
+            maxLine={2}
+            minLine={1}
+            url={mapURL}
+            />
         </div>
     )
 }

--- a/trails-app/src/components/Map.js
+++ b/trails-app/src/components/Map.js
@@ -8,18 +8,15 @@ export default function Map(props) {
     mapURL += props.searchObj.zip + "&destination=" + lat + "," + long
     return(
         <div className="detail-column-container-center">
-            <img className="google-image" src="https://www.xda-developers.com/files/2019/06/google-maps-india.jpg"/>
-            <br></br>
-            <a href={mapURL} target = "_blank" >Click here for directions</a>
             <div className = "google-link">
-            <ReactTinyLink
-            cardSize="large"
-            showGraphic={true}
-            description ="Click here for directions to your hike."
-            maxLine={2}
-            minLine={1}
-            url={mapURL}
-            />
+                <ReactTinyLink
+                    cardSize="large"
+                    showGraphic={true}
+                    description ="Click here for directions to your hike."
+                    maxLine={2}
+                    minLine={1}
+                    url={mapURL}
+                />
             </div>
         </div>
     )

--- a/trails-app/src/components/Map.js
+++ b/trails-app/src/components/Map.js
@@ -11,6 +11,7 @@ export default function Map(props) {
             <img className="google-image" src="https://www.xda-developers.com/files/2019/06/google-maps-india.jpg"/>
             <br></br>
             <a href={mapURL} target = "_blank" >Click here for directions</a>
+            <div className = "google-link">
             <ReactTinyLink
             cardSize="large"
             showGraphic={true}
@@ -19,6 +20,7 @@ export default function Map(props) {
             minLine={1}
             url={mapURL}
             />
+            </div>
         </div>
     )
 }

--- a/trails-app/src/views/DetailView.css
+++ b/trails-app/src/views/DetailView.css
@@ -93,6 +93,7 @@
     flex-direction: column;
   }
   .detail-img{
+    margin: 0px;
     height: auto;
     width:100%;
   }

--- a/trails-app/src/views/DetailView.css
+++ b/trails-app/src/views/DetailView.css
@@ -93,8 +93,6 @@
     flex-direction: column;
   }
   .detail-img{
-    margin-top: 10px;
-    margin-left: 10px;
     height: auto;
     width:100%;
   }

--- a/trails-app/src/views/DetailView.css
+++ b/trails-app/src/views/DetailView.css
@@ -86,8 +86,8 @@
     margin-right: auto;
   }
 
-  /* Detail View configuration for window size less than 800px */
-@media only screen and (max-width: 800px) {
+  /* Detail View configuration for window size less than 900px */
+@media only screen and (max-width: 900px) {
   .detail-row-main-container{
     display: flex;
     flex-direction: column;

--- a/trails-app/src/views/DetailView.css
+++ b/trails-app/src/views/DetailView.css
@@ -1,97 +1,91 @@
-.detail-row-container{
-    display: flex;
-    flex-direction: row;
-    justify-content: space-evenly;
-  }
 .detail-row-main-container{
   display: flex;
   flex-direction: row;
   justify-content: space-evenly;
 }
-  
-  .detail-column-container-center{
+
+.detail-row-container{
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     justify-content: space-evenly;
-    text-align: center;
-  }
-
-  .detail-column-container-left{
-    display: flex;
-    flex-direction: column;
-    justify-content: space-evenly;
-    text-align: left;
-  }
-
-  .detail-column-container-right{
-    display: flex;
-    flex-direction: column;
-    justify-content: space-evenly;
-    text-align: right;
   }
   
-  .detail-img{
-    margin-top: 10px;
-    margin-left: 10px;
-    height: 50%;
-    width:50%;
-  }
+.detail-column-container-center{
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  text-align: center;
+}
+
+.detail-column-container-left{
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  text-align: left;
+}
+
+.detail-column-container-right{
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  text-align: right;
+}
   
-  .detail-text{
-    text-align: center;
-    margin: 10px;
-  }
-
-  i{
-      margin: 2px;
-  }
-
-  .tooltip {
-    position: relative;
-    display: inline-block;
-  }
+.detail-img{
+  margin-top: 10px;
+  margin-left: 10px;
+  height: 50%;
+  width:50%;
+}
   
-  .tooltip .tooltiptext {
-    visibility: hidden;
-    width: 250px;
-    background-color: black;
-    color: white;
-    text-align: center;
-    border-radius: 6px;
-    padding: 5px 0;
-    position: absolute;
-    z-index: 1;
-    right: 105%;
-    top:"-13px";
-  }
+.detail-text{
+  text-align: center;
+  margin: 10px;
+}
 
-  .tooltip .tooltiptext::after {
-    content: "";
-    position: absolute;
-    top: 50%;
-    left: 100%;
-    margin-top: -5px;
-    border-width: 5px;
-    border-style: solid;
-    border-color: transparent transparent transparent black;
-  }
-  .tooltip:hover .tooltiptext {
-    visibility: visible;
-  }
+i{
+  margin: 2px;
+}
 
-  .google-image {
-    width: 60%;
-    height: 60%;
-    margin-left: auto;
-    margin-right: auto;
-  }
+.tooltip {
+  position: relative;
+  display: inline-block;
+}
+  
+.tooltip .tooltiptext {
+  visibility: hidden;
+  width: 250px;
+  background-color: black;
+  color: white;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px 0;
+  position: absolute;
+  z-index: 1;
+  right: 105%;
+  top:"-13px";
+}
 
-  .google-link{
-    width: 60%;
-    height: 60%;
-    margin-left: auto;
-    margin-right: auto;
-  }
+.tooltip .tooltiptext::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 100%;
+  margin-top: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: transparent transparent transparent black;
+}
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+}
+
+.google-link{
+  width: 60%;
+  height: 60%;
+  margin-left: auto;
+  margin-right: auto;
+}
 
   /* Detail View configuration for window size less than 900px */
 @media only screen and (max-width: 900px) {

--- a/trails-app/src/views/DetailView.css
+++ b/trails-app/src/views/DetailView.css
@@ -86,7 +86,7 @@
     margin-right: auto;
   }
 
-  ReactTinyLink {
+  .google-link{
     width: 60%;
     height: 60%;
     margin-left: auto;

--- a/trails-app/src/views/DetailView.css
+++ b/trails-app/src/views/DetailView.css
@@ -3,6 +3,11 @@
     flex-direction: row;
     justify-content: space-evenly;
   }
+.detail-row-main-container{
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+}
   
   .detail-column-container-center{
     display: flex;
@@ -26,7 +31,10 @@
   }
   
   .detail-img{
-    margin: 10px;
+    margin-top: 10px;
+    margin-left: 10px;
+    height: 50%;
+    width:50%;
   }
   
   .detail-text{
@@ -77,3 +85,17 @@
     margin-left: auto;
     margin-right: auto;
   }
+
+  /* Detail View configuration for window size less than 800px */
+@media only screen and (max-width: 800px) {
+  .detail-row-main-container{
+    display: flex;
+    flex-direction: column;
+  }
+  .detail-img{
+    margin-top: 10px;
+    margin-left: 10px;
+    height: auto;
+    width:100%;
+  }
+}

--- a/trails-app/src/views/DetailView.css
+++ b/trails-app/src/views/DetailView.css
@@ -86,6 +86,13 @@
     margin-right: auto;
   }
 
+  ReactTinyLink {
+    width: 60%;
+    height: 60%;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
   /* Detail View configuration for window size less than 900px */
 @media only screen and (max-width: 900px) {
   .detail-row-main-container{

--- a/trails-app/src/views/DetailView.js
+++ b/trails-app/src/views/DetailView.js
@@ -12,7 +12,7 @@ export default function DetailView(props) {
   var gear = new Gear(hike);
 
   return (
-    <div className ="detail-row-container" id= {hike.id}>
+    <div className ="detail-row-main-container" id= {hike.id}>
       <img className="detail-img" src = {hike.largeimgURL}/>
       <div className="detail-column-container" style={{alignItems:"center"}}>
         <h1 className="detail-text">{hike.title}</h1>


### PR DESCRIPTION
Fixed Github issue #19 - summaries extend off results list item in certain conditions
- I fixed this issue by hiding the hike summary in the results list item when window size is under a specific amount.
- I also have the current temp move underneath hike difficulty for smaller window sizes

Fixed Github issue #20 - Detail view: Hike image does not accommodate smaller window sizes
- I fixed this by changing the container alignment with smaller windows sizes such that image will appear above the detail view text vs. to the left of.

Fixed Github issue #21 - Detail view: google maps showing default image instead of specific hike location.
- I fixed this by utilizing a react tiny link which shows a page preview of a url on the page where the link is placed. This works well for showing general hike location relative to search zip code.